### PR TITLE
fix: enable all feature routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,13 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Index from "./pages/Index";
-import NotFound from "./pages/NotFound";
+import { lazy, Suspense } from "react";
+
+const Index = lazy(() => import("./pages/Index"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const Compare = lazy(() => import("./pages/Compare"));
+const Risk = lazy(() => import("./pages/Risk"));
+const Documentation = lazy(() => import("./pages/Documentation"));
 
 const queryClient = new QueryClient();
 
@@ -14,17 +19,20 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/compare" element={<Index />} />
-          <Route path="/risk" element={<Index />} />
-          <Route path="/docs" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<div className="p-4">Carregando...</div>}>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/compare" element={<Compare />} />
+            <Route path="/risk" element={<Risk />} />
+            <Route path="/docs" element={<Documentation />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>
 );
 
 export default App;
+

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { NavLink } from "react-router-dom";
 
 interface NavigationProps {
-  currentStep: number;
-  onStepChange: (step: number) => void;
+  currentStep?: number;
+  onStepChange?: (step: number) => void;
 }
 
 const steps = [
@@ -29,23 +30,42 @@ export function Navigation({ currentStep, onStepChange }: NavigationProps) {
           </div>
           
           <div className="hidden md:flex items-center space-x-1">
-            {steps.map((step) => (
-              <Button
-                key={step.id}
-                variant={currentStep === step.id ? "default" : "ghost"}
-                onClick={() => onStepChange(step.id)}
-                className={cn(
-                  "flex flex-col items-center h-auto py-2 px-4 transition-smooth",
-                  currentStep === step.id && "bg-gradient-primary text-primary-foreground shadow-glow"
-                )}
-              >
-                <span className="font-medium text-xs">{step.label}</span>
-                <span className="text-xs opacity-80">{step.description}</span>
-              </Button>
-            ))}
+            {typeof currentStep !== "undefined" && onStepChange &&
+              steps.map((step) => (
+                <Button
+                  key={step.id}
+                  variant={currentStep === step.id ? "default" : "ghost"}
+                  onClick={() => onStepChange(step.id)}
+                  className={cn(
+                    "flex flex-col items-center h-auto py-2 px-4 transition-smooth",
+                    currentStep === step.id &&
+                      "bg-gradient-primary text-primary-foreground shadow-glow"
+                  )}
+                >
+                  <span className="font-medium text-xs">{step.label}</span>
+                  <span className="text-xs opacity-80">{step.description}</span>
+                </Button>
+              ))}
           </div>
           
           <div className="flex items-center space-x-2">
+            <NavLink to="/compare">
+              {({ isActive }) => (
+                <Button variant={isActive ? "default" : "ghost"}>
+                  Comparar
+                </Button>
+              )}
+            </NavLink>
+            <NavLink to="/risk">
+              {({ isActive }) => (
+                <Button variant={isActive ? "default" : "ghost"}>Risco</Button>
+              )}
+            </NavLink>
+            <NavLink to="/docs">
+              {({ isActive }) => (
+                <Button variant={isActive ? "default" : "ghost"}>Docs</Button>
+              )}
+            </NavLink>
             <Button variant="outline" size="sm">
               Ajuda
             </Button>

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -1,7 +1,24 @@
 import { StrategyComparison } from "@/components/comparison/strategy-comparison";
+import { Navigation } from "@/components/ui/navigation";
+import { useNavigate } from "react-router-dom";
 
 const Compare = () => {
-  return <StrategyComparison />;
+  const navigate = useNavigate();
+
+  const handleStepChange = (step: number) => {
+    if (step === 5) {
+      navigate("/risk");
+    } else if (step < 4) {
+      navigate("/");
+    }
+  };
+
+  return (
+    <>
+      <Navigation currentStep={4} onStepChange={handleStepChange} />
+      <StrategyComparison />
+    </>
+  );
 };
 
 export default Compare;

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -1,11 +1,19 @@
 import { StrategyComparison } from "@/components/comparison/strategy-comparison";
 import { Navigation } from "@/components/ui/navigation";
 import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useOnboardingSession } from "@/hooks/use-onboarding-session";
 
 const Compare = () => {
   const navigate = useNavigate();
+  const { setCurrentStep } = useOnboardingSession();
+
+  useEffect(() => {
+    setCurrentStep(4);
+  }, [setCurrentStep]);
 
   const handleStepChange = (step: number) => {
+    setCurrentStep(step);
     if (step === 5) {
       navigate("/risk");
     } else if (step < 4) {

--- a/src/pages/Documentation.tsx
+++ b/src/pages/Documentation.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Navigation } from "@/components/ui/navigation";
 import { 
   Book, 
   Code, 
@@ -14,9 +15,11 @@ import {
   Play
 } from "lucide-react";
 
-export function Documentation() {
+export default function Documentation() {
   return (
-    <div className="max-w-6xl mx-auto space-y-8">
+    <>
+      <Navigation />
+      <div className="max-w-6xl mx-auto space-y-8">
       {/* Header */}
       <div className="text-center space-y-4">
         <h1 className="text-4xl font-bold">Documentação</h1>
@@ -378,5 +381,6 @@ export function Documentation() {
         </CardContent>
       </Card>
     </div>
+    </>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { TrendingUp, Shield, BarChart3, Sparkles } from "lucide-react";
 import heroImage from "@/assets/hero-image.jpg";
 import { useOnboardingSession, type RiskProfile } from "@/hooks/use-onboarding-session";
+import { useNavigate } from "react-router-dom";
 
 interface BacktestAsset {
   symbol: string;
@@ -25,6 +26,17 @@ const Index = () => {
     setHasCompletedOnboarding,
     resetOnboarding,
   } = useOnboardingSession();
+
+  const navigate = useNavigate();
+
+  const handleStepChange = (step: number) => {
+    setCurrentStep(step);
+    if (step === 4) {
+      navigate("/compare");
+    } else if (step === 5) {
+      navigate("/risk");
+    }
+  };
 
   const handleRiskProfileComplete = (profile: RiskProfile) => {
     setRiskProfile(profile);
@@ -66,7 +78,7 @@ const Index = () => {
   if (!hasCompletedOnboarding && currentStep === 1) {
     return (
       <div className="min-h-screen bg-gradient-hero">
-        <Navigation currentStep={currentStep} onStepChange={setCurrentStep} />
+        <Navigation currentStep={currentStep} onStepChange={handleStepChange} />
         
         {/* Hero Section */}
         <div className="relative">
@@ -176,7 +188,7 @@ const Index = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Navigation currentStep={currentStep} onStepChange={setCurrentStep} />
+      <Navigation currentStep={currentStep} onStepChange={handleStepChange} />
       
       <div className="container mx-auto px-4 py-8">
         {/* Profile Header (when onboarding completed) */}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,7 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
+import { Navigation } from "@/components/ui/navigation";
+import { Button } from "@/components/ui/button";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,15 +14,18 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <>
+      <Navigation />
+      <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center bg-gray-100">
+        <div className="text-center space-y-4">
+          <h1 className="text-4xl font-bold">404</h1>
+          <p className="text-xl text-gray-600">Oops! Page not found</p>
+          <Button asChild>
+            <Link to="/">Voltar ao início</Link>
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/Risk.tsx
+++ b/src/pages/Risk.tsx
@@ -1,11 +1,19 @@
 import { RiskManagement } from "@/components/risk/risk-management";
 import { Navigation } from "@/components/ui/navigation";
 import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useOnboardingSession } from "@/hooks/use-onboarding-session";
 
 const Risk = () => {
   const navigate = useNavigate();
+  const { setCurrentStep } = useOnboardingSession();
+
+  useEffect(() => {
+    setCurrentStep(5);
+  }, [setCurrentStep]);
 
   const handleStepChange = (step: number) => {
+    setCurrentStep(step);
     if (step === 4) {
       navigate("/compare");
     } else if (step < 4) {

--- a/src/pages/Risk.tsx
+++ b/src/pages/Risk.tsx
@@ -1,7 +1,24 @@
 import { RiskManagement } from "@/components/risk/risk-management";
+import { Navigation } from "@/components/ui/navigation";
+import { useNavigate } from "react-router-dom";
 
 const Risk = () => {
-  return <RiskManagement />;
+  const navigate = useNavigate();
+
+  const handleStepChange = (step: number) => {
+    if (step === 4) {
+      navigate("/compare");
+    } else if (step < 4) {
+      navigate("/");
+    }
+  };
+
+  return (
+    <>
+      <Navigation currentStep={5} onStepChange={handleStepChange} />
+      <RiskManagement />
+    </>
+  );
 };
 
 export default Risk;


### PR DESCRIPTION
## Summary
- wire up dedicated Compare, Risk, and Documentation pages
- lazy load page components to reduce initial bundle
- expose Compare, Risk, Docs via navigation bar
- highlight active navigation links for current page context
- show onboarding step progress on Compare and Risk views
- route onboarding steps to feature pages for step-driven navigation
- mount navigation header on 404 page for consistent access to routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5cdaf3bfc832da23df1bdfa56a813